### PR TITLE
Update to how IO Config read out for [IOT] command. 

### DIFF
--- a/SIO_ESP32WRM_Relay_X2/SIO_ESP32WRM_Relay_X2.ino
+++ b/SIO_ESP32WRM_Relay_X2/SIO_ESP32WRM_Relay_X2.ino
@@ -4,9 +4,11 @@
 //#define ENABLE_WIFI_SUPPORT
 //#define USE_DIGESTAUTH //use this for a little extra security. Maybe change the digest and default password too.
 
-#define VERSIONINFO "SIO_ESP32WRM_Relay_X2 1.0.9"
+#define VERSIONINFO "SIO_ESP32WRM_Relay_X2 1.1.0"
 #define COMPATIBILITY "SIOPlugin 0.1.1"
 #define DEFAULT_HOSTS_NAME "SIOControler-New"
+#define FLASHSIZE "4MB with spiffs(1.2MB APP/1.5 SPIFFS)"
+
 
 #include "TimeRelease.h"
 #include <ArduinoJson.h>  
@@ -250,6 +252,9 @@ void checkSerial(){
       Serial.println(VERSIONINFO);
       Serial.print("CP:");
       Serial.println(COMPATIBILITY);
+      Serial.print("FS:");
+      Serial.println(FLASHSIZE);
+      
     }
     else if (command == "IC") { //io count.
       ack();
@@ -473,15 +478,14 @@ bool validateNewIOConfig(String ioConfig){
 }
 
 
-
 int getIOType(String typeName){
-  if(typeName == "INPUT"){return 1;}
-  if(typeName == "OUTPUT"){return 2;}
-  if(typeName == "INPUT_PULLUP"){return 5;}
-  if(typeName == "INPUT_PULLDOWN"){return 9;}
-  if(typeName == "OUTPUT_OPEN_DRAIN"){return 18;} //not sure on this value have to double check
+  if(typeName == "INPUT"){return INPUT;}
+  if(typeName == "OUTPUT"){return OUTPUT;}
+  if(typeName == "INPUT_PULLUP"){return INPUT_PULLUP;}
+  if(typeName == "INPUT_PULLDOWN"){return INPUT_PULLDOWN;}
+  if(typeName == "OUTPUT_OPEN_DRAIN"){return OUTPUT_OPEN_DRAIN;} //not sure on this value have to double check
+  if(typeName == "OUTPUT_PWM"){return OUTPUT_PWM;} //not sure on this value have to double check
 }
-
 
 bool loadIOConfig(){
   
@@ -491,6 +495,8 @@ if (!SPIFFS.exists("/IOConfig.json"))
     debugMsg("Using Default Config");
     return false;
   }
+  
+  
   File configfile = SPIFFS.open("/IOConfig.json","r");
 
   DynamicJsonDocument doc(2048);

--- a/SIO_ESP32WRM_Relay_X2/global.h
+++ b/SIO_ESP32WRM_Relay_X2/global.h
@@ -15,6 +15,7 @@
 //Additionally IO 34,35,36,and39 can only be used as inputs.
 //reference: https://randomnerdtutorials.com/esp32-pinout-reference-gpios/
 
+
 #define IO0 34//  input only (Must configure (in code)without pullup or down. These inputs do not have these on chip)
 #define IO1 35//  input only  (Must configure (in code)without pullup or down. These inputs do not have these on chip)
 #define IO2 36//  input only (Labeled as SVP)  (Must configure (in code)without pullup or down. These inputs do not have these on chip)
@@ -30,6 +31,7 @@
 #define IO12 17//  Relay2
 #define IO13 23//  output has the board built in LED attached. Active LOW.
 
+#define OUTPUT_PWM -2 //Output Type For PWM
 
 #define IOSize  14 //number should be one more than the IO# :) (must include the idea of Zero) 
 bool _debug = false;
@@ -71,12 +73,22 @@ void updateIOConfig(String newIOConfig){
 }
 
 
+
 String getIOTypeString(int ioType){
-  if (ioType == 1){return "INPUT";}
-  if (ioType == 2){return "OUTPUT";}
-  if (ioType == 5){return "INPUT_PULLUP";}
-  if (ioType == 9){return "INPUT_PULLDOWN";}
-  if (ioType == 18){return "OUTPUT_OPEN_DRAIN";}
+  if (ioType == INPUT){return "INPUT";}
+  if (ioType == OUTPUT){return "OUTPUT";}
+  if (ioType == INPUT_PULLUP){return "INPUT_PULLUP";}
+  if (ioType == INPUT_PULLDOWN){return "INPUT_PULLDOWN";}
+  if (ioType == OUTPUT_OPEN_DRAIN){return "OUTPUT_OPEN_DRAIN";}
+  
+  if (ioType == OUTPUT_PWM){
+    #ifdef ENABLE_PWM_SUPPORT
+    return "OUTPUT_PWM";
+    #else
+    return "UnSupported OUTPUT_PWM";
+    #endif
+    }
+  
 }
 
 


### PR DESCRIPTION
Corrects issue where an update to the firmware may have corrupted the stored IO config settings. 

Only and issue if you stored a changed config from the default set. The issue was that it would not read out correctly after an update to latest version of firmware causing system to use default config. 

Also minor add of PMW IO type but functionality not Implemented yet.  Will make use of in future update.

