### PR TITLE
Update to v1.0.1 levels. Support for PWM in esp32

### DIFF
--- a/README.md
+++ b/README.md
@@ -9,4 +9,7 @@ If you have a board / MCU you perfer, you likley can just modify the Firmware an
 If you are looking for some support, I will be working on the wiki. Check it out. If you dont find what you are looking for there, I lurk a lot on the [OctoPrint community site](https://community.octoprint.org/). Post there in the plugins section and I will likely see it and respond. 
 
 
-### Note that as up version 1.1.2 (2-26-2024) The SIO_ESP32WRM_Relay_x(n) firmware requires the latest ESP32 boards lib to support PWM Output being developed. 
+## Prerequisites for ESP32 Versions.
+
+1. [`Arduino IDE 1.8.19+` for Arduino](https://github.com/arduino/Arduino). [![GitHub release](https://img.shields.io/github/release/arduino/Arduino.svg)](https://github.com/arduino/Arduino/releases/latest)
+2. [`ESP32 Core 2.0.6+`](https://github.com/espressif/arduino-esp32) for ESP32-based boards. [![Latest release](https://img.shields.io/github/release/espressif/arduino-esp32.svg)](https://github.com/espressif/arduino-esp32/releases/latest/).

--- a/SIO_Arduino_Minimal_Base/SIO_Arduino_Minimal_Base.ino
+++ b/SIO_Arduino_Minimal_Base/SIO_Arduino_Minimal_Base.ino
@@ -1,11 +1,12 @@
-//Note that this sketch is too large due to some of the Serial String use for an Arduino Nano.
+//Note that this sketch is too large due to some of the Serial String use for an Arduino Nano if you have a board with less
+//memory than an ATMega2560 use the nano base firmware. 
   
 
-#define VERSIONINFO "SIO_Arduino_General 1.0.8"
+#define VERSIONINFO "SIO_Arduino_General 1.0.9"
 #define COMPATIBILITY "SIOPlugin 0.1.1"
 #include "TimeRelease.h"
 #include <Bounce2.h>
-
+#include <EEPROM.h>
 
 
 #define IOSize  19 //number should be one more than the IO# :) (must include the idea of Zero)  
@@ -40,17 +41,71 @@ int IO[IOSize];
 Bounce Bnc[IOSize];
 bool EventTriggeringEnabled = 1;
  
-//void(* resetFunc) (void) = 0;
- 
-bool isOutPut(int IOP){
-  return IOType[IOP] == OUTPUT; 
-}
- 
-void ConfigIO(){
-  
-  Serial.println("Setting IO");
+
+void StoreIOConfig(){
+  #ifdef includeDebug
+    debugMsg(F("< Saving IO Config"));
+  #endif
+  int cs = 0;
   for (int i=0;i<IOSize;i++){
-    if(i > 10){ //if it is an input
+    EEPROM.update(i+1,IOType[i]); //store IO type map in eeprom but only if they are different... Will make it last a little longer but unlikely to really matter.:) 
+    cs += IOType[i];
+    #ifdef includeDebug
+      if(_debug){debugMsgPrefx();Serial.print(F("EE Pos:"));Serial.print(i);Serial.print(F(" typ:"));Serial.println(IOType[i]);Serial.print(F(" Cur CS:"));Serial.println(cs);}
+    #endif
+  }
+  EEPROM.update(0,cs); 
+  #ifdef includeDebug
+    if(_debug){debugMsgPrefx();Serial.print(F("Chk-S:"));Serial.println(cs);}
+  #endif
+}
+
+
+void FetchIOConfig(){
+  int cs = EEPROM.read(0); //specifics of number is completely random. 
+  int tempCS = 0;
+  int IOTTmp[IOSize];
+  
+
+  for (int i=0;i<IOSize;i++){ //starting at 2 to avoide reading in first 2 IO points.
+    IOTTmp[i] = EEPROM.read(i+1);//retreve IO type map from eeprom. 
+    tempCS += IOTTmp[i];
+  }
+
+  #ifdef includeDebug
+    if(_debug){debugMsgPrefx();Serial.print(F("tmpCS: "));Serial.println(tempCS);}
+  #endif    
+  
+  if(cs == tempCS){
+    if(_debug){Serial.println("aply EE IO");}
+    for (int i=0;i<IOSize;i++){
+      IOType[i] = IOTTmp[i];
+    }
+    return;  
+  }
+  #ifdef includeDebug
+  if(_debug){debugMsgPrefx();Serial.print(F("!:Using IO defaults"));Serial.println(tempCS);}
+  #endif
+}
+
+
+bool isOutPut(int IOP){
+  //return (IOType[IOP] == OUTPUT || IOType[IOP] == OUTPUT_PWM);
+  return (IOType[IOP] == OUTPUT);
+}
+
+bool isINPUT(int IOP){
+  return (IOType[IOP] == INPUT)||(IOType[IOP] == INPUT_PULLUP);
+}
+
+
+
+void ConfigIO(){
+  #ifdef includeDebug
+    debugMsg(F("< Set IO"));
+  #endif
+  for (int i=0;i<IOSize;i++){
+    if(IOType[i] == 0 ||IOType[i] == 2 || IOType[i] == 3){ //if it is an input
       pinMode(IOMap[i],IOType[i]);
       Bnc[i].attach(IOMap[i],IOType[i]);
       Bnc[i].interval(5);
@@ -59,27 +114,40 @@ void ConfigIO(){
       digitalWrite(IOMap[i],LOW);
     }
   }
- 
+
 }
- 
- 
- 
+
+
 TimeRelease IOReport;
+TimeRelease IOTimer[9];
 TimeRelease ReadyForCommands;
- 
 unsigned long reportInterval = 3000;
- 
+
+
+
 void setup() {
   // put your setup code here, to run once:
   Serial.begin(115200);
   delay(300);
-  debugMsg(VERSIONINFO);
-  debugMsg("Initializing IO");
-  ConfigIO();
+  #ifdef includeDebug
+    _debug = true;
+  #endif
   
+  debugMsg(VERSIONINFO);
+  
+  #ifdef includeDebug 
+    debugMsg(F("< Types"));
+  #endif
+  
+  FetchIOConfig();
+  ConfigIO();
   reportIOTypes();
-  debugMsg("End Types");
- 
+  
+  #ifdef includeDebug 
+    debugMsg(F("> Types"));
+    _debug = true;
+  #endif
+  
   //need to get a baseline state for the inputs and outputs.
   for (int i=0;i<IOSize;i++){
     IO[i] = digitalRead(IOMap[i]);  
@@ -87,14 +155,13 @@ void setup() {
   
   IOReport.set(100ul);
   ReadyForCommands.set(reportInterval); //Initial short delay resets will be at 3x
-  DisplayIOTypeConstants();
-  
+  //Serial.println(F("RR")); //send ready for commands    
 }
- 
- 
+
+
 bool _pauseReporting = false;
 bool ioChanged = false;
- 
+
 //*********************Start loop***************************//
 void loop() {
   // put your main code here, to run repeatedly:
@@ -106,18 +173,17 @@ void loop() {
       Serial.println("RR"); //send ready for commands   
       ReadyForCommands.set(reportInterval *3);
     }
+    
   }
   
 }
 //*********************End loop***************************//
- 
+
 void reportIO(bool forceReport){
   if (IOReport.check()||forceReport){
-    Serial.print("IO:");
+    Serial.print(F("IO:"));
     for (int i=0;i<IOSize;i++){
-      //if(IOType[i] == 1 ){ //if it is an input
-        IO[i] = digitalRead(IOMap[i]);  
-      //}
+      IO[i] = digitalRead(IOMap[i]);  
       Serial.print(IO[i]);
     }
     Serial.println();
@@ -125,56 +191,59 @@ void reportIO(bool forceReport){
     
   }
 }
- 
+
 bool checkIO(){
   bool changed = false;
   
   for (int i=0;i<IOSize;i++){
-    if(!isOutPut(i)){
-      if(_debug){debugMsgPrefx();Serial.print("NOT Output IO#:");Serial.println(i);}
+    if(isINPUT(i)){
       Bnc[i].update();
-      
       if(Bnc[i].changed()){
        changed = true;
        IO[i]=Bnc[i].read();
-       if(_debug){debugMsg("Input Changed: "+String(i));}
+       if(_debug){debugMsgPrefx();Serial.print(F("Input Changed: "));Serial.println(i);}
       }
-    }else{
-      //debugMsgPrefx();Serial.print("IS Output IO#:");Serial.println(i);
+    }else if(isOutPut(i)){
       //is the current state of this output not the same as it was on last report.
       //this really should not happen if the only way an output can be changed is through Serial commands.
       //the serial commands force a report after it takes action.
       if(IO[i] != digitalRead(IOMap[i])){
-        if(_debug){debugMsg("Output Changed: "+String(i));}
+        if(_debug){debugMsgPrefx();Serial.print(F("Output Changed: "));Serial.println(i);}
         changed = true;
       }
+    //}else if(IOType[i] == INPUT_DHT || IOType[i] == OUTPUT_PWM ){
+      //not checking digital change on this type of IO
     }
-    
   }
     
   return changed;
 }
- 
- 
+
 void reportIOTypes(){
-  Serial.print("IT:");
+  Serial.print(F("IT:"));
   for (int i=0;i<IOSize;i++){
     Serial.print(String(IOType[i]));
-    Serial.print(",");
-    //if(i<IOSize-1){Serial.print(";");}
+    Serial.print(F(","));
   }
   Serial.println();
-  debugMsg("IOSize:" + String(IOSize));
+  #ifdef includeDebug 
+    if(_debug){debugMsgPrefx();Serial.print(F("IOSize:")); Serial.println(String(IOSize));}
+  #endif
 }
- 
+
 void DisplayIOTypeConstants(){
-  debugMsgPrefx();Serial.print("INPUT:");Serial.println(INPUT);//1
-  debugMsgPrefx();Serial.print("OUTPUT:");Serial.println(OUTPUT);//2
-  debugMsgPrefx();Serial.print("INPUT_PULLUP:");Serial.println(INPUT_PULLUP);//5
-  //debugMsgPrefx();Serial.print("INPUT_PULLDOWN:");Serial.println(INPUT_PULLDOWN);//9
-  //debugMsgPrefx();Serial.print("OUTPUT_OPEN_DRAIN:");Serial.println(OUTPUT_OPEN_DRAIN);//18
+  Serial.print(F("TC "));
+  Serial.print(F("INPUT:"));Serial.print(INPUT);Serial.print(",");//0
+  Serial.print(F("OUTPUT:"));Serial.print(OUTPUT);Serial.print(",");//1
+
+  Serial.print(F("INPUT_PULLUP:"));Serial.println(INPUT_PULLUP);//2  NOTE*********fix the new line if you add additional response types.
+  //Serial.print(F("INPUT_PULLUP:"));Serial.print(INPUT_PULLUP);Serial.print(",");//5
+  //Serial.print("INPUT_PULLDOWN:");Serial.print(INPUT_PULLDOWN);Serial.print(",");//9
+  //Serial.print("OUTPUT_OPEN_DRAIN:");Serial.print(OUTPUT_OPEN_DRAIN);Serial.print(",");//18
+  //Serial.print("INPUT_DHT:");Serial.print(INPUT_DHT);Serial.print(",");//-3
+  //Serial.print("OUTPUT_PWM:");Serial.println(OUTPUT_PWM);//-2 
 }
- 
+
 void checkSerial(){
   if (Serial.available()){
     
@@ -188,23 +257,31 @@ void checkSerial(){
     if(sepPos !=-1){
       command = buf.substring(0,sepPos);
       value = buf.substring(sepPos+1);;
+      
+      #ifdef includeDebug
       if(_debug){
-        debugMsg("command:[" + command + "]");
-        debugMsg("value:[" + value+ "]");
+        debugMsgPrefx();Serial.print(F("cmnd:["));Serial.print(command);Serial.println(F("]"));
+        debugMsgPrefx();Serial.print(F("val:["));Serial.print(value);Serial.println(F("]"));
       }
+      #endif 
     }else{
       command = buf;
+      #ifdef includeDebug
       if(_debug){
-        debugMsg("command:[" + command + "]");
+        debugMsgPrefx();Serial.print(F("cmnd:["));Serial.print(command);Serial.println(F("]"));
       }
+      #endif
     }
     if(command.startsWith("N") || command == "M115"){
       ack();
-      Serial.println("Recieved a command that looks like OctoPrint thinks I am a printer.");
-      Serial.println("This is not a printer it is a SIOControler. Sending disconnect host action command.");
-      Serial.println("To avoide this you should place the name/path of this port in the [Blacklisted serial ports] section of Octoprint");
-      Serial.println("This can be found in the settings dialog under 'Serial Connection'");
-      Serial.println("//action:disconnect");
+      
+      Serial.println(F("Looks like OctoPrint thinks I am a printer."));
+      Serial.println(F("I not printer; Am SIOControler. Send disconnect host action cmnd."));
+      #ifdef includeDebug
+      Serial.println(F("To avoide this you should place the name/path of this port in the [Blacklisted serial ports] section of Octoprint"));
+      Serial.println(F("This can be found in the settings dialog under 'Serial Connection'"));
+      #endif
+      Serial.println(F("//action:disconnect"));
     }
     else if(command == "BIO"){ 
       ack();
@@ -217,34 +294,57 @@ void checkSerial(){
       return;
     }
     else if (command == "VC"){//version and compatibility
-      Serial.print("VI:");
+      Serial.print(F("VI:"));
       Serial.println(VERSIONINFO);
-      Serial.print("CP:");
+      Serial.print(F("CP:"));
       Serial.println(COMPATIBILITY);
+      Serial.print("XT BRD:");
+      #ifdef __AVR_ATmega1280__
+        Serial.print("ATmega1280");
+      #elif __AVR_ATmega2560__
+        Serial.println("ATmega2560");
+      #elif __AVR_ATmega328P__
+        Serial.println("ATmega328P");
+      #elif __AVR_ATmega168__
+        Serial.println("ATmega168");
+      #elif __AVR_ATmega32U4__
+        Serial.println("ATmega32U4");
+      #elif __AVR_ATmega16U4__
+        Serial.println("ATmega16U4");
+      #else
+        Serial.println(F("Unknown board"));
+      #endif
     }
     else if (command == "IC") { //io count.
       ack();
-      Serial.print("IC:");
+      Serial.print(F("IC:"));
       Serial.println(IOSize -1);
       return;
     }
     
     else if(command =="debug" && value.length() == 1){
       ack();
-      if(value == "1"){
-        _debug = true;
-        debugMsg("Serial debug On");
-      }else{
-        _debug=false;
-        debugMsg("Serial debug Off");
-      }
+      #ifdef includeDebug
+        if(value == "1"){
+          _debug = true;
+          debugMsg(F("Debug On"));
+        }else{
+          _debug=false;
+          debugMsg(F("Debug Off"));
+        }
+      #else
+      debugMsg(F("debug disabled"));
+      #endif
       return;
     }
     else if(command=="CIO"){ //set IO Configuration
       ack();
-      debugMsg("Live IO confiuration feature is only partially supported.");
       if(value.length() == 0){ //set IO Configuration
-        debugMsg("ERROR: command value out of range");
+      if(_debug){
+        #ifdef includeDebug
+        debugMsg(F("ERR: val out of rng"));
+        #endif
+      }
       }else if (validateNewIOConfig(value)){
         updateIOConfig(value);
       }
@@ -253,8 +353,7 @@ void checkSerial(){
     
     else if(command=="SIO"){
       ack();
-      debugMsg("Live IO confiuration feature is not avalible in this firmware");
-      debugMsg("To change IO configuration you must edit and update firmware");
+      StoreIOConfig();
       return;
     }
     else if(command=="IOT"){
@@ -262,24 +361,30 @@ void checkSerial(){
       reportIOTypes();
       return;
     }
+    else if(command == "TC"){
+      ack();
+      DisplayIOTypeConstants();
+      return;
+    }
     
     //Set IO point high or low (only applies to IO set to output)
     else if(command =="IO"){ 
       ack();
       if(value.length() < 3){
-        debugMsg("ERROR: command value out of range");
+        debugMsg(F("ERR: value out of range"));
         return;
       }
       
       if(value.indexOf(" ") >=1 && value.substring(value.indexOf(" ")+1).length()==1){//is there at least one character for the IO number and the value for this IO point must be only one character (1||0)
         String sIOPoint = value.substring(0,value.indexOf(" "));
         String sIOSet = value.substring(value.indexOf(" ")+1); // leaving this as a string allows for easy check on correct posible values
-                 
+        #ifdef includeDebug
         if(_debug){
-          debugMsg("IO#:"+ sIOPoint);
-          debugMsg("GPIO#:"+ String(IOMap[sIOPoint.toInt()]));
-          debugMsg("Set to:"+ sIOSet);
+          debugMsgPrefx();Serial.print(F("IO#:"));Serial.println(sIOPoint);
+          debugMsgPrefx();Serial.print(F("GPIO#:"));Serial.println(IOMap[sIOPoint.toInt()]);
+          debugMsgPrefx();Serial.print(F("Set to:"));Serial.println(sIOSet);
         }
+        #endif
 
         //checks to see if the IO point is not a number if the string is not a zero but the number is that means it was not a number
         if(isOutPut(sIOPoint.toInt()) && !(sIOPoint.toInt() == 0 && sIOPoint != "0") ){
@@ -290,15 +395,15 @@ void checkSerial(){
               digitalWrite(IOMap[sIOPoint.toInt()],LOW);
             }
           }else{
-            debugMsg("ERROR: Attempt to set IO to a value that is not valid");   
+            debugMsg(F("ERR: Atmpt set IO value not valid"));   
           }
         }else{
-          debugMsg("ERROR: Attempt to set IO which is not an output");   
+          debugMsg(F("ERR: Atmpt set IO not an output"));   
         }
         //delay(200); // give it a moment to finish changing the 
         reportIO(true);
       }else{
-        debugMsg("ERROR: IO point or value is invalid");   
+        debugMsg(F("ERR: invalid cmd/vlu"));   
       }
       return;
     }
@@ -312,16 +417,15 @@ void checkSerial(){
           reportInterval = newTime;
           IOReport.clear();
           IOReport.set(reportInterval);
-          debugMsg("Auto report timing changed to:" +String(reportInterval));
+          debugMsgPrefx();Serial.print(F("ART now:"));Serial.println(String(reportInterval));
         }else{
-          debugMsg("ERROR: command value out of range: Min(500) Max(2147483647)");
+          debugMsg(F("ERR: # out of range."));
         }
         return;
       }
-      debugMsg("ERROR: bad format number out of range.(500- 2147483647); actual sent [" + value + "]; Len["+String(value.length())+"]");
+      debugMsg(F("ERR: # out of range."));
       return; 
     }
-    
     //Enable event trigger reporting Mostly used for E-Stop
     else if(command == "SE"){
       ack();
@@ -329,113 +433,140 @@ void checkSerial(){
         if(value == "1" || value == "0"){
           EventTriggeringEnabled = value.toInt();
         }else{
-          debugMsg("ERROR: command value out of range");
+          debugMsg(F("EROR: val out of range"));
         }
       }else{
-        debugMsg("ERROR: command value not sent or bad format");
+        debugMsg(F("EROR: val bad format"));
       }
       return;
     }
-    else if (command == "restart" || command == "reset" || command == "reboot"){
+    else if (command == "restart" || command == "reset" || command == "reboot"){ //could remove this completely to save some memory
       ack();
-      debugMsg("Command not supported.");
+      debugMsg(F("!supported"));
     }
- 
+
     //Get States 
     else if(command == "GS"){
       ack();
       reportIO(true);
       return; 
     }
+   
     else{
-      debugMsg("ERROR: Unrecognized command["+command+"]");
+      debugMsgPrefx();Serial.print(F("ERR: bad cmnd["));Serial.print(command);Serial.println(F("]"));
     }
   }
 }
- 
+
+
 void ack(){
-  Serial.println("OK");
+  Serial.println(F("OK"));
 }
 
-//Because there is no way to store between uses, know that chaneges will not survive restarts.
 bool validateNewIOConfig(String ioConfig){
+  int newConfig[IOSize];
+  int incomingSize = 0;
   
-  if(ioConfig.length() != IOSize){
-    if(_debug){debugMsg("IOConfig validation failed(Wrong len)");}
+  if(ioConfig.length() == (IOSize*3+1)){
+    debugMsgPrefx();
+    Serial.print(F("IOConfig validation failed(Wrong len): required minimal len["));
+    Serial.print((IOSize*3+1));
+    Serial.print(F("] supplied len["));
+    Serial.print(ioConfig.length());
+    Serial.println("]" );
     return false;  
   }
- 
-  for (int i=0;i<IOSize;i++){
-    int pointType = ioConfig.substring(i,i+1).toInt();
-    if(pointType > 4){//cant be negative. we would have a bad parse on the number so no need to check negs
-      if(_debug){
-        debugMsg("IOConfig validation failed");debugMsg("Bad IO Point type: index[" +String(i)+"] type["+pointType+"]");
-      }
+
+  for(int i=0;i<IOSize;i++){
+    int istart = i*3;
+    String token = ioConfig.substring(istart,istart+2);
+    if(_debug){debugMsgPrefx();Serial.print(F("Token: "));Serial.println(token.toInt());}
+    newConfig[i] = token.toInt();
+    if(!isValidIOType(newConfig[i])){
+      debugMsgPrefx();Serial.print(F("IO Type is invalid: ["));Serial.print(token.toInt());Serial.print(F("] @ position:["));Serial.print(i);Serial.println(F("]"));
       return false;
     }
+    incomingSize = i;
   }
-  if(_debug){debugMsg("IOConfig validation good");}
-  return true; //seems its a good set of point Types.
-}
+
+  if(incomingSize+1 != IOSize){
+    debugMsg(F("IOConfig validation failed. IO pattern did not have the correct number of point configs."));
+    debugMsg("IO Count: " + String(IOSize));
+    debugMsg("Parttern Count: " + String(incomingSize));
+    return false;
+  }
+
+  if(_debug){
+    debugMsg(F("New Config passed Validation"));
+    debugMsgPrefx();
+    for(int i=0;i< IOSize;i++){
+      Serial.print("[");Serial.print(newConfig[i]);Serial.print("],");
+    }
+    Serial.println("");
+  }
+
+ return true; //seems its a good set of point Types.
  
+}
+
+//newIOConfig format is "##,##,##,##,##..." where each ## should be a 2 char string 
+//representing an integer with a leading zero where needed. A negative number like -3 does not need a leading zero.  
+//Where as a number like 1 or  5 should belike this 01 05
 void updateIOConfig(String newIOConfig){
-  for (int i=2;i<IOSize;i++){//start at 2 to avoid D0 and D1
-    int nIOC = newIOConfig.substring(i,i+1).toInt();
-    if(IOType[i] != nIOC){
-      IOType[i] = nIOC;
-      if(nIOC == OUTPUT){
-        digitalWrite(IOMap[i],LOW); //set outputs to low since they will be high coming from INPUT_PULLUP
-      }
+
+ for(int i=0;i<IOSize;i++){
+    int istart = i*3;
+    String token = newIOConfig.substring(istart,istart+2);
+    IOType[i] = token.toInt();
+    if(isOutPut(i)){
+      digitalWrite(IOMap[i],LOW); //set outputs to low since they will be high coming from INPUT_PULLUP
     }
   }
 }
 
-
-//Note that this list and values must be updated to match the expected for your MCU 
-int getIOType(String typeName){
-  if(typeName == "INPUT"){return 1;}
-  if(typeName == "OUTPUT"){return 2;}
-  if(typeName == "INPUT_PULLUP"){return 5;}
-  //if(typeName == "INPUT_PULLDOWN"){return 9;}
-  //if(typeName == "OUTPUT_OPEN_DRAIN"){return 18;} //not sure on this value have to double check
-  Serial.print("ERROR: unrecognized IOType name IOType["+typeName+"]");
-  return 0;
-}
-
-
-//Note that this list and values must be updated to match the expected for your MCU  
 String getIOTypeString(int ioType){
-  if (ioType == 1){return "INPUT";}
-  if (ioType == 2){return "OUTPUT";}
-  if (ioType == 5){return "INPUT_PULLUP";}
-  //if (ioType == 9){return "INPUT_PULLDOWN";}
-  //if (ioType == 18){return "OUTPUT_OPEN_DRAIN";}
-  Serial.print("ERROR: unrecognized IOType value[");Serial.print(ioType);Serial.println("]");
-  return "";
+  if (ioType == INPUT){return F("INPUT");}
+  if (ioType == OUTPUT){return F("OUTPUT");}
+  if (ioType == INPUT_PULLUP){return F("INPUT_PULLUP");}
+  //if (ioType == INPUT_PULLDOWN){return F("INPUT_PULLDOWN");}
+  //if (ioType == OUTPUT_OPEN_DRAIN){return F("OUTPUT_OPEN_DRAIN");}
+  //if (ioType == OUTPUT_PWM){return F("OUTPUT_PWM");}
+  //if (ioType == INPUT_DHT){return F("INPUT_DHT");}
+  
+  return "UnSupported Type: " + String(ioType);
+  
 }
 
 
-
-bool strToUnsignedLong(String& data, unsigned long& result) {
-  data.trim();
-  long tempResult = data.toInt();
-  if (String(tempResult) != data) { // check toInt conversion
-    // for very long numbers, will return garbage, non numbers returns 0
-   // Serial.print(F("not a long: ")); Serial.println(data);
-    return false;
-  } else if (tempResult < 0) { //  OK check sign
-   // Serial.print(F("not an unsigned long: ")); Serial.println(data);
-    return false;
-  } //else
-  result = tempResult;
-  return true;
+bool isValidIOType(int ioType){
+  if(ioType == INPUT){return true;}
+  if(ioType == OUTPUT){return true;}
+  if(ioType == INPUT_PULLUP){return true;}
+  //if(ioType == INPUT_PULLDOWN){return true;}
+  //if(ioType == OUTPUT_OPEN_DRAIN){return true;}
+  //if(ioType == OUTPUT_PWM){return true;}
+  //if(ioType == INPUT_DHT){return true;}
+  return false;
 }
- 
+
+
+int getIOType(String typeName){
+  if(typeName == "INPUT"){return INPUT;}
+  if(typeName == "OUTPUT"){return OUTPUT;}
+  if(typeName == "INPUT_PULLUP"){return INPUT_PULLUP;}
+  //if(typeName == "INPUT_PULLDOWN"){return INPUT_PULLDOWN;}
+  //if(typeName == "OUTPUT_OPEN_DRAIN"){return OUTPUT_OPEN_DRAIN;} //not sure on this value have to double check
+  //if(typeName == "OUTPUT_PWM"){return OUTPUT_PWM;} //not sure on this value have to double check
+  //if(typeName == "INPUT_DHT"){return INPUT_DHT;} //not sure on this value have to double check
+  return -1;
+}
+
+
 void debugMsg(String msg){
   debugMsgPrefx();
   Serial.println(msg);
 }
  
 void debugMsgPrefx(){
-  Serial.print("DG:");
+  Serial.print(F("DG:"));
 }

--- a/SIO_ESP32WRM_Relay_X4/global.h
+++ b/SIO_ESP32WRM_Relay_X4/global.h
@@ -33,6 +33,32 @@
 #define IO15 23 //  output only LED 
 
 #define OUTPUT_PWM -2 //Output Type For PWM
+#define INPUT_DHT -3 //Input Type for DHT Module Reading.
+
+#include "DHTesp.h" //https://github.com/beegee-tokyo/DHTesp/tree/master
+#define DHTSensor DHTesp::DHT22
+#define DHTSize 4
+int dhtSizeDynamic = DHTSize; //This will be dynamic up to 4. Actual count of usage is what will determin if a measurement will be made.
+DHTesp dht_sensor[DHTSize]; //allow up to 4 of these sensors to be used
+TempAndHumidity DTHValues[DHTSize];
+
+#include "ESP32_FastPWM.h"
+#define PWMSize 4
+int pwmSizeDynamic = PWMSize; //This will be dynamic up to 4. Actual count of usage is what will determin if a measurement will be made.
+int pwmMap[PWMSize] = {-1,-1,-1,-1}; //used to quickly get PWM_Instance from IO Point Id. (-1 is an invalid IO Point position.)
+ESP32_FAST_PWM* PWM_Instance[PWMSize];
+uint8_t PWMChannel[PWMSize]{0,1,2,3};
+float PWMFrequency[PWMSize] = {1000.0f,1000.0f,1000.0f,1000.0f}; //default Frequency is 1k
+float PWMDutyCycle[PWMSize] = {0.0f,0.0f,0.0f,0.0f};
+int PWMResolution[PWMSize] = {12,12,12,12};  //Resolution is 4096 this is ok res for up to 10k Frequency lower resolution wiht higher Frequencies. 
+
+// Max resolution is 20-bit
+// Resolution 65536 (16-bit) for lower frequencies, OK @ 1K
+// Resolution  4096 (12-bit) for lower frequencies, OK @ 10K
+// Resolution  1024 (10-bit) for higher frequencies, OK @ 50K
+// Resolution  256  ( 8-bit)for higher frequencies, OK @ 100K, 200K
+// Resolution  128  ( 7-bit) for higher frequencies, OK @ 500K
+
 
 #define IOSize  16 //number should be one more than the IO# :) (must include the idea of Zero) 
 bool _debug = false;
@@ -43,7 +69,6 @@ int IO[IOSize];
 Bounce Bnc[IOSize];
 bool EventTriggeringEnabled = 1;
 
-  
 
 void debugMsgPrefx(){
   Serial.print("DG:");
@@ -55,20 +80,26 @@ void debugMsg(String msg){
 }
 
 bool isOutPut(int IOP){
-  return (IOType[IOP] == OUTPUT);
+  return (IOType[IOP] == OUTPUT || IOType[IOP] == OUTPUT_OPEN_DRAIN || IOType[IOP] == OUTPUT_PWM);
+}
+
+bool isINPUT(int IOP){
+  return (IOType[IOP] == INPUT)||(IOType[IOP] == INPUT_PULLUP)||(IOType[IOP] == INPUT_PULLDOWN);
 }
 
 
 
+//newIOConfig format is "##,##,##,##,##..." where each ## should be a 2 char string 
+//representing an integer with a leading zero where needed. A negative number like -3 does not need a leading zero.  
+//Where as a number like 1 or  5 should belike this 01 05
 void updateIOConfig(String newIOConfig){
-  Serial.println("************************review this for ESP32*********************");
-  for (int i=2;i<IOSize;i++){//start at 2 to avoid D0 and D1 
-    int nIOC = newIOConfig.substring(i,i+1).toInt();
-    if(IOType[i] != nIOC){
-      IOType[i] = nIOC;
-      if(nIOC == OUTPUT ||nIOC == OUTPUT_OPEN_DRAIN){
-        digitalWrite(IOMap[i],LOW); //set outputs to low since they will be high coming from INPUT_PULLUP
-      }
+
+ for(int i=0;i<IOSize;i++){
+    int istart = i*3;
+    String token = newIOConfig.substring(istart,istart+2);
+    IOType[i] = token.toInt();
+    if(isOutPut(i)){
+      digitalWrite(IOMap[i],LOW); //set outputs to low since they will be high coming from INPUT_PULLUP
     }
   }
 }
@@ -81,14 +112,10 @@ String getIOTypeString(int ioType){
   if (ioType == INPUT_PULLUP){return "INPUT_PULLUP";}
   if (ioType == INPUT_PULLDOWN){return "INPUT_PULLDOWN";}
   if (ioType == OUTPUT_OPEN_DRAIN){return "OUTPUT_OPEN_DRAIN";}
+  if (ioType == OUTPUT_PWM){return "OUTPUT_PWM";}
+  if (ioType == INPUT_DHT){return "INPUT_DHT";}
   
-  if (ioType == OUTPUT_PWM){
-    #ifdef ENABLE_PWM_SUPPORT
-    return "OUTPUT_PWM";
-    #else
-    return "UnSupported OUTPUT_PWM";
-    #endif
-    }
+  return "UnSupported unknown Type: " + String(ioType);
   
 }
 

--- a/SIO_ESP32WRM_Relay_X4/wifiCommon.h
+++ b/SIO_ESP32WRM_Relay_X4/wifiCommon.h
@@ -311,7 +311,7 @@ void SetupWifi(){
     }
     debugMsgPrefx();Serial.print("WifiMode:");
     Serial.println(wifiConfig.wifimode);
-    if(wifiConfig.wifimode == "WIFI_AP"){
+    if(String(wifiConfig.wifimode) == "WIFI_AP"){
       InAPMode  = true;
     }else{
       InAPMode  = false;
@@ -375,7 +375,7 @@ void DebugSettingsConfig(){
 String settingsConfigFile = "/config/settingsConfig.json";
 bool loadSettings(){
   if(_debug){
-    debugMsgPrefx();Serial.print("SettingsConfig file path: ");Serial.println(settingsConfigFile);
+    debugMsgPrefx();Serial.print("SettingsConfig(Web) file path: ");Serial.println(settingsConfigFile);
   }
   
   if (!SPIFFS.exists(settingsConfigFile))

--- a/SIO_Nano_Base/SIO_Nano_Base.ino
+++ b/SIO_Nano_Base/SIO_Nano_Base.ino
@@ -10,12 +10,12 @@
 //cmnd is short for command
 //Reciently v1.0.0.6 I have made heavey use of the F String Macro to move strings to the Program space. This has helped alot. 
 //There is plenty of program space so using the F macro seems to be the answer to the run time memory issue when using string. 
-//At the time of this writing enabled is 46%(1104 bytes free) and disabled is 43%(1167 bytes free) free memrory for runtime
+//At the time of this writing enabled is 46%(1093 bytes free) and disabled is 44%(1144 bytes free) free memrory for runtime
 //I may in the near future just remove the includeDegbug define and the associated checks. 
 #define includeDebug
 
 
-#define VERSIONINFO "NanoSerialIO 1.0.7"
+#define VERSIONINFO "NanoSerialIO 1.0.8"
 #define COMPATIBILITY "SIOPlugin 0.1.1"
 #include "TimeRelease.h"
 #include <Bounce2.h>
@@ -42,6 +42,11 @@
 #define IO17 A5 // pin24/A5
 //Note that A6 and A7 can only be used as Analog inputs. 
 //Arduino Documentation also warns that Any input that it floating is suseptable to random readings. Best way to solve this is to use a pull up(avalible as an internal) or down resister(external).I set all internals to pull up see IOTypes
+
+//these are not supported yet and may never be in the nano. They are eneded here to facilitate some reuse of code. 
+//also note that the Mega328 only supports INPUT,OUTPUT,INPUT_PULLUP as part of the Arduino.h lib.
+//#define OUTPUT_PWM -2 //Output Type For PWM
+//#define INPUT_DHT -3 //Input Type for DHT Module Reading. 
 
 
 #define IOSize  18 //(0-19)note that this equates to 18 bacause of D0andD1 as Serial.
@@ -101,12 +106,19 @@ void FetchIOConfig(){
 
 
 bool isOutPut(int IOP){
-  return IOType[IOP] == OUTPUT; 
+  //return (IOType[IOP] == OUTPUT || IOType[IOP] == OUTPUT_PWM);
+  return (IOType[IOP] == OUTPUT);
 }
+
+bool isINPUT(int IOP){
+  return (IOType[IOP] == INPUT)||(IOType[IOP] == INPUT_PULLUP);
+}
+
+
 
 void ConfigIO(){
   #ifdef includeDebug
-    debugMsg("< Set IO");
+    debugMsg(F("< Set IO"));
   #endif
   for (int i=0;i<IOSize;i++){
     if(IOType[i] == 0 ||IOType[i] == 2 || IOType[i] == 3){ //if it is an input
@@ -200,28 +212,24 @@ bool checkIO(){
   bool changed = false;
   
   for (int i=0;i<IOSize;i++){
-    if(!isOutPut(i)){
+    if(isINPUT(i)){
       Bnc[i].update();
       if(Bnc[i].changed()){
        changed = true;
        IO[i]=Bnc[i].read();
-       #ifdef includeDebug 
-       if(_debug){debugMsg("IO Chg: "+String(i));}
-       #endif
+       if(_debug){debugMsgPrefx();Serial.print(F("Input Changed: "));Serial.println(i);}
       }
-    }else{
-      
+    }else if(isOutPut(i)){
       //is the current state of this output not the same as it was on last report.
       //this really should not happen if the only way an output can be changed is through Serial commands.
       //the serial commands force a report after it takes action.
       if(IO[i] != digitalRead(IOMap[i])){
-        #ifdef includeDebug 
-        if(_debug){debugMsgPrefx();Serial.print(F("IO Chg: "));Serial.print(String(i));}
-        #endif
+        if(_debug){debugMsgPrefx();Serial.print(F("Output Changed: "));Serial.println(i);}
         changed = true;
       }
+    //}else if(IOType[i] == INPUT_DHT || IOType[i] == OUTPUT_PWM ){
+      //not checking digital change on this type of IO
     }
-    
   }
     
   return changed;
@@ -237,6 +245,19 @@ void reportIOTypes(){
   #ifdef includeDebug 
     if(_debug){debugMsgPrefx();Serial.print(F("IOSize:")); Serial.println(String(IOSize));}
   #endif
+}
+
+void DisplayIOTypeConstants(){
+  Serial.print(F("TC "));
+  Serial.print(F("INPUT:"));Serial.print(INPUT);Serial.print(",");//0
+  Serial.print(F("OUTPUT:"));Serial.print(OUTPUT);Serial.print(",");//1
+
+  Serial.print(F("INPUT_PULLUP:"));Serial.println(INPUT_PULLUP);//2  NOTE*********fix the new line if you add additional response types.
+  //Serial.print(F("INPUT_PULLUP:"));Serial.print(INPUT_PULLUP);Serial.print(",");//5
+  //Serial.print("INPUT_PULLDOWN:");Serial.print(INPUT_PULLDOWN);Serial.print(",");//9
+  //Serial.print("OUTPUT_OPEN_DRAIN:");Serial.print(OUTPUT_OPEN_DRAIN);Serial.print(",");//18
+  //Serial.print("INPUT_DHT:");Serial.print(INPUT_DHT);Serial.print(",");//-3
+  //Serial.print("OUTPUT_PWM:");Serial.println(OUTPUT_PWM);//-2 
 }
 
 void checkSerial(){
@@ -255,15 +276,15 @@ void checkSerial(){
       
       #ifdef includeDebug
       if(_debug){
-        debugMsg("cmnd:[" + command + "]");
-        debugMsg("val:[" + value+ "]");
+        debugMsgPrefx();Serial.print(F("cmnd:["));Serial.print(command);Serial.println(F("]"));
+        debugMsgPrefx();Serial.print(F("val:["));Serial.print(value);Serial.println(F("]"));
       }
       #endif 
     }else{
       command = buf;
       #ifdef includeDebug
       if(_debug){
-        debugMsg("cmnd:[" + command + "]");
+        debugMsgPrefx();Serial.print(F("cmnd:["));Serial.print(command);Serial.println(F("]"));
       }
       #endif
     }
@@ -293,6 +314,22 @@ void checkSerial(){
       Serial.println(VERSIONINFO);
       Serial.print(F("CP:"));
       Serial.println(COMPATIBILITY);
+      Serial.print("XT BRD:");
+      #ifdef __AVR_ATmega1280__
+        Serial.print("ATmega1280");
+      #elif __AVR_ATmega2560__
+        Serial.println("ATmega2560");
+      #elif __AVR_ATmega328P__
+        Serial.println("ATmega328P");
+      #elif __AVR_ATmega168__
+        Serial.println("ATmega168");
+      #elif __AVR_ATmega32U4__
+        Serial.println("ATmega32U4");
+      #elif __AVR_ATmega16U4__
+        Serial.println("ATmega16U4");
+      #else
+        Serial.println(F("Unknown board"));
+      #endif
     }
     else if (command == "IC") { //io count.
       ack();
@@ -340,6 +377,11 @@ void checkSerial(){
       reportIOTypes();
       return;
     }
+    else if(command == "TC"){
+      ack();
+      DisplayIOTypeConstants();
+      return;
+    }
     
     //Set IO point high or low (only applies to IO set to output)
     else if(command =="IO"){ 
@@ -354,9 +396,9 @@ void checkSerial(){
         String sIOSet = value.substring(value.indexOf(" ")+1); // leaving this as a string allows for easy check on correct posible values
         #ifdef includeDebug
         if(_debug){
-          debugMsg("IO#:"+ sIOPoint);
-          debugMsg("GPIO#:"+ String(IOMap[sIOPoint.toInt()]));
-          debugMsg("Set to:"+ sIOSet);
+          debugMsgPrefx();Serial.print(F("IO#:"));Serial.println(sIOPoint);
+          debugMsgPrefx();Serial.print(F("GPIO#:"));Serial.println(IOMap[sIOPoint.toInt()]);
+          debugMsgPrefx();Serial.print(F("Set to:"));Serial.println(sIOSet);
         }
         #endif
 
@@ -438,50 +480,101 @@ void ack(){
 }
 
 bool validateNewIOConfig(String ioConfig){
+  int newConfig[IOSize];
+  int incomingSize = 0;
   
-  if(ioConfig.length() != IOSize){
-    #ifdef includeDebug
-      if(_debug){debugMsg(F("IOConfig validation failed(Wrong len)"));}
-    #endif
+  if(ioConfig.length() == (IOSize*3+1)){
+    debugMsgPrefx();
+    Serial.print(F("IOConfig validation failed(Wrong len): required minimal len["));
+    Serial.print((IOSize*3+1));
+    Serial.print(F("] supplied len["));
+    Serial.print(ioConfig.length());
+    Serial.println("]" );
     return false;  
   }
 
-  for (int i=0;i<IOSize;i++){
-    int pointType = ioConfig.substring(i,i+1).toInt();
-    if(pointType > 4){//cant be negative. we would have a bad parse on the number so no need to check negs
-      #ifdef includeDebug
-      if(_debug){
-        debugMsgPrefx();Serial.println(F("IO validation failed"));
-        debugMsgPrefx();Serial.print(F("Bad IO Type: index["));Serial.print(i);Serial.print(F("] type["));Serial.print(pointType);Serial.println(F("]"));
-      }
-      #endif
+  for(int i=0;i<IOSize;i++){
+    int istart = i*3;
+    String token = ioConfig.substring(istart,istart+2);
+    if(_debug){debugMsgPrefx();Serial.print(F("Token: "));Serial.println(token.toInt());}
+    newConfig[i] = token.toInt();
+    if(!isValidIOType(newConfig[i])){
+      debugMsgPrefx();Serial.print(F("IO Type is invalid: ["));Serial.print(token.toInt());Serial.print(F("] @ position:["));Serial.print(i);Serial.println(F("]"));
       return false;
     }
+    incomingSize = i;
   }
-  #ifdef includeDebug
-  if(_debug){debugMsg(F("IOConfig validation good"));}
-  #endif
-  return true; //seems its a good set of point Types.
+
+  if(incomingSize+1 != IOSize){
+    debugMsg(F("IOConfig validation failed. IO pattern did not have the correct number of point configs."));
+    debugMsg("IO Count: " + String(IOSize));
+    debugMsg("Parttern Count: " + String(incomingSize));
+    return false;
+  }
+
+  if(_debug){
+    debugMsg(F("New Config passed Validation"));
+    debugMsgPrefx();
+    for(int i=0;i< IOSize;i++){
+      Serial.print("[");Serial.print(newConfig[i]);Serial.print("],");
+    }
+    Serial.println("");
+  }
+
+ return true; //seems its a good set of point Types.
+ 
 }
 
+//newIOConfig format is "##,##,##,##,##..." where each ## should be a 2 char string 
+//representing an integer with a leading zero where needed. A negative number like -3 does not need a leading zero.  
+//Where as a number like 1 or  5 should belike this 01 05
 void updateIOConfig(String newIOConfig){
-  for (int i=2;i<IOSize;i++){//start at 2 to avoid D0 and D1
-    int nIOC = newIOConfig.substring(i,i+1).toInt();
-    if(IOType[i] != nIOC){
-      IOType[i] = nIOC;
-      if(nIOC == OUTPUT){
-        digitalWrite(IOMap[i],LOW); //set outputs to low since they will be high coming from INPUT_PULLUP
-      }
+
+ for(int i=0;i<IOSize;i++){
+    int istart = i*3;
+    String token = newIOConfig.substring(istart,istart+2);
+    IOType[i] = token.toInt();
+    if(isOutPut(i)){
+      digitalWrite(IOMap[i],LOW); //set outputs to low since they will be high coming from INPUT_PULLUP
     }
   }
 }
 
+String getIOTypeString(int ioType){
+  if (ioType == INPUT){return F("INPUT");}
+  if (ioType == OUTPUT){return F("OUTPUT");}
+  if (ioType == INPUT_PULLUP){return F("INPUT_PULLUP");}
+  //if (ioType == INPUT_PULLDOWN){return F("INPUT_PULLDOWN");}
+  //if (ioType == OUTPUT_OPEN_DRAIN){return F("OUTPUT_OPEN_DRAIN");}
+  //if (ioType == OUTPUT_PWM){return F("OUTPUT_PWM");}
+  //if (ioType == INPUT_DHT){return F("INPUT_DHT");}
+  
+  return "UnSupported Type: " + String(ioType);
+  
+}
+
+
+bool isValidIOType(int ioType){
+  if(ioType == INPUT){return true;}
+  if(ioType == OUTPUT){return true;}
+  if(ioType == INPUT_PULLUP){return true;}
+  //if(ioType == INPUT_PULLDOWN){return true;}
+  //if(ioType == OUTPUT_OPEN_DRAIN){return true;}
+  //if(ioType == OUTPUT_PWM){return true;}
+  //if(ioType == INPUT_DHT){return true;}
+  return false;
+}
+
+
 int getIOType(String typeName){
-  if(typeName == "INPUT"){return 0;}
-  if(typeName == "OUTPUT"){return 1;}
-  if(typeName == "INPUT_PULLUP"){return 2;}
-  if(typeName == "INPUT_PULLDOWN"){return 3;}
-  if(typeName == "OUTPUT_OPEN_DRAIN"){return 4;} //not sure on this value have to double check
+  if(typeName == "INPUT"){return INPUT;}
+  if(typeName == "OUTPUT"){return OUTPUT;}
+  if(typeName == "INPUT_PULLUP"){return INPUT_PULLUP;}
+  //if(typeName == "INPUT_PULLDOWN"){return INPUT_PULLDOWN;}
+  //if(typeName == "OUTPUT_OPEN_DRAIN"){return OUTPUT_OPEN_DRAIN;} //not sure on this value have to double check
+  //if(typeName == "OUTPUT_PWM"){return OUTPUT_PWM;} //not sure on this value have to double check
+  //if(typeName == "INPUT_DHT"){return INPUT_DHT;} //not sure on this value have to double check
+  return -1;
 }
 
 


### PR DESCRIPTION
Update to v1.0.1 levels. Support for PWM in esp32 and prep to remove extra versions. 

This firmware has support for PWM output configuration and control in the ESP32 targets. 

All versions have a new format for updating IO Config over serial at runtime.  This will be used in an upcoming Sub-Plugin called SIO_Configurator.  Allowing a change in the IO config without updating and installing new firmware revision.

Arduino targets are now all up to latest support for basic digital IO. (these firmwares will currently do not support PWM(outputs) or DHT(inputs).  

### In next update I will be archiving these firmware paths.

- SIO_nano_base (if you have a nano you will be able to adjust the static IO settings in the SIO_Arduinoi_minmal_Base)
- SIO_CanaduinoPLC_Mega328 (if you have one of these boards you will be able to adjust the static IO settings in the SIO_Arduinoi_minmal_Base)
- SIO_ESP32WRM_Relay_X4 (Essentially the same as the X2 version with some changes in IO Config. You can adjust commented areas in the Global.h file to setup for X4 in the "SIO_ESP32WMR" version going forward. 
- SIO_ESP32WRM_Relay_X2 will be renamed to "SIO_ESP32WRM" 
- SIO_ESP12F_Relay_X2 will be renamed to "SIO_ESP8266" you can adjust the IO in the global.h file as needed.
